### PR TITLE
MW does not support page views

### DIFF
--- a/lib/WikiBlender.js
+++ b/lib/WikiBlender.js
@@ -48,7 +48,7 @@ var WikiBlender = {
 				userCounts = userCounts.join("");
 				userCounts = "<h4>Most active users - last 30 days</h4><ol>" + userCounts + "</ol>";
 
-				var wikiViewsText = stats.views == null ? stats.views + " views, " : "";
+				var wikiViewsText = stats.views != null ? stats.views + " views, " : "";
 
 				$(articlesElement)
 					.attr("title", userCounts)

--- a/lib/WikiBlender.js
+++ b/lib/WikiBlender.js
@@ -1,6 +1,7 @@
 var totalArticles = 0,
 	totalImages = 0;
 	totalViews = 0,
+	totalViewsText = "",
 	totalEdits = 0,
 	totalActiveUsers = [];
 
@@ -47,12 +48,14 @@ var WikiBlender = {
 				userCounts = userCounts.join("");
 				userCounts = "<h4>Most active users - last 30 days</h4><ol>" + userCounts + "</ol>";
 
+				var wikiViewsText = stats.views == null ? stats.views + " views, " : "";
+
 				$(articlesElement)
 					.attr("title", userCounts)
 					.html(
 						stats.articles + " articles, " +
 						stats.images + " uploaded files<br />" +
-						stats.views + " views, " +
+						wikiViewsText +
 						stats.edits + " edits<br />" +
 						allusers.length + " active contributors"
 					)
@@ -62,8 +65,12 @@ var WikiBlender = {
 
 				totalArticles += stats.articles;
 				totalImages += stats.images;
-				totalViews += stats.views;
 				totalEdits += stats.edits;
+
+				if ( stats.views != null ) {
+					totalViews += stats.views;
+					totalViewsText = totalViews + " views, ";
+				}
 
 				for(var u in allusers) {
 					totalActiveUsers.push( allusers[u].name );
@@ -74,7 +81,7 @@ var WikiBlender = {
 					"Across all wikis: " +
 					totalArticles + " articles, " +
 					totalImages + " uploaded files, " +
-					totalViews + " views, " +
+					totalViewsText +
 					totalEdits + " edits, " +
 					totalActiveUsers.length + " unique editors in last 30 days"
 				);


### PR DESCRIPTION
MediaWiki 1.25+ does not track page views. Eventually WikiBlender should use page views from Extension:HitCounter, Extension:Wiretap, or other sources, but for now simply don't show page views if they're not available.
